### PR TITLE
Add Docker setup for ALGOL W (AWE), wrapper script, and example programs

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+############################
+# Builder stage
+############################
+FROM debian:trixie-slim AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-lc"]
+# Install OCaml + build tools
+RUN set -euxo pipefail && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      make \
+      gcc \
+      g++ \
+      binutils \
+      m4 \
+      pkg-config \
+      libgc-dev \
+      bubblewrap \
+      unzip \
+      python3 \
+      python3-markdown \
+      ocaml \
+      ocamlbuild && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+# Clone and build AWE
+RUN set -euxo pipefail && \
+    git clone https://github.com/glynawe/awe.git . && \
+    make clean && make && make install
+# Ensure the static archive has an index
+RUN set -euxo pipefail && \
+    test -f /usr/local/lib/libawe.a && \
+    ranlib /usr/local/lib/libawe.a
+# Verify expected files installed
+RUN set -euxo pipefail && \
+    test -x /usr/local/bin/awe && \
+    test -f /usr/local/include/awe.h && \
+    test -f /usr/local/include/aweio.h && \
+    test -f /usr/local/include/awe.mk && \
+    test -f /usr/local/lib/libawe.a && \
+    test -f /usr/local/share/doc/awe/awe.html && \
+    test -f /usr/local/share/man/man1/awe.1 && \
+    test -f /usr/local/share/man/man7/awe.mk.7
+############################
+# Runtime stage
+############################
+FROM debian:trixie-slim
+ENV DEBIAN_FRONTEND=noninteractive
+# We need gcc/binutils to build generated C code
+RUN set -euxo pipefail && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ocaml-nox \
+      gcc \
+      binutils \
+      libgc1 \
+      libgc-dev \
+      libstdc++6 && \
+    rm -rf /var/lib/apt/lists/*
+# Copy built artifacts
+COPY --from=builder /usr/local/ /usr/local/
+# ======================================================
+# Ensure ld treats /usr/local/lib first for static libs
+# ======================================================
+ENV LIBRARY_PATH=/usr/local/lib
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/awe"]

--- a/Docker/alw.sh
+++ b/Docker/alw.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Wrapper script to compile and run ALGOL W (.alw) programs using the AWE compiler.
+# Usage: bash alw.sh program.alw
+# - Produces output directly
+# - Accepts interactive input (read) just like running locally
+# - Leaves no compiled binaries behind (clean run)
+#
+# The script delegates compilation and execution to a pre-built Docker image
+# generated from the Dockerfile in this directory ("abuajamieh/alw").
+#
+# Author: Maksim AbuAjamieh
+# Date: 06/12/2025
+
+set -euo pipefail
+
+IMAGE="abuajamieh/alw"
+ALW_FILE="${1:-}"
+[ -z "$ALW_FILE" ] && { echo "need .alw file"; exit 1; }
+[ ! -f "$ALW_FILE" ] && { echo "file not found: $ALW_FILE"; exit 1; }
+
+BASENAME=$(basename "$ALW_FILE" .alw)
+
+# detect TTY
+if [ -t 0 ] && [ -t 1 ]; then
+    DOCKER_FLAGS="-it"
+else
+    DOCKER_FLAGS="-i"
+fi
+
+echo "► Compiling with awe..."
+docker run --rm \
+  -v "$(pwd)":/work \
+  -w /work \
+  "$IMAGE" \
+  "$ALW_FILE"
+
+echo "► Running program..."
+docker run $DOCKER_FLAGS --rm \
+  --entrypoint /bin/sh \
+  -v "$(pwd)":/work \
+  -w /work \
+  "$IMAGE" \
+  -c "
+    cp $BASENAME /tmp/$BASENAME &&
+    cd /tmp &&
+    chmod +x $BASENAME &&
+    ( ./$BASENAME ) ;
+    rc=\$? ;
+    rm -f $BASENAME ;
+    exit \$rc
+  "
+
+# cleanup of host binary
+echo "► Cleaning local binary..."
+rm -f "$BASENAME" 2>/dev/null || true
+
+echo "✓ Completed."

--- a/Docker/test1.alw
+++ b/Docker/test1.alw
@@ -1,0 +1,6 @@
+COMMENT This is a quick test program to run with the wrapper script;
+COMMENT Example: bash alw.sh test1.alw;
+
+begin
+	write("Hello world");
+end.

--- a/Docker/test2.alw
+++ b/Docker/test2.alw
@@ -1,0 +1,8 @@
+COMMENT This is a quick test program to run with the wrapper script;
+COMMENT Example: bash alw.sh test2.alw;
+begin
+	integer n;
+	write("Enter an integer number: ");
+	read(n);
+	write(n);
+end.


### PR DESCRIPTION
- Dockerfile builds an AWE image (Or you can use the one I pushed: abuajamieh/alw).
- alw.sh: A wrapper script that compiles and runs .alw programs interactively using a docker container (Defaults to abuajamieh/alw).
- test1.alw and test2.alw serve as sample programs.
- wrapper cleans up temporary binaries automatically.